### PR TITLE
Use metadeps to specify pkg-config dependencies declaratively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,8 @@ Bindings to the system libz library (also known as zlib).
 libc = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3"
+metadeps = "1"
 gcc = "0.3.17"
+
+[package.metadata.pkg-config]
+zlib = "1.2.3.4"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-extern crate pkg_config;
+extern crate metadeps;
 extern crate gcc;
 
 use std::env;
@@ -26,7 +26,7 @@ fn main() {
     let want_static = env::var("LIBZ_SYS_STATIC").unwrap_or(String::new()) == "1";
     if !want_static &&
        !(host.contains("apple") && target.contains("apple")) &&
-        pkg_config::find_library("zlib").is_ok() {
+        metadeps::probe().is_ok() {
         return
     }
 


### PR DESCRIPTION
This makes it easier for distribution packaging tools to generate
appropriate package dependencies.