### PR TITLE
Run pkg-config on MSVC

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,6 @@ fn main() {
     let want_static =
         cfg!(feature = "static") || env::var("LIBZ_SYS_STATIC").unwrap_or(String::new()) == "1";
     if !want_static &&
-       !target.contains("msvc") && // pkg-config just never works here
        !(host_and_target_contain("freebsd") ||
          host_and_target_contain("dragonfly"))
     {


### PR DESCRIPTION
The root cause of the pkg-config failure on MSVC seems to be that pkg-config-rs is appending .lib, while it shouldn't because rustc already does that on Windows.

@sdroege is fixing this issue in https://github.com/alexcrichton/pkg-config-rs/pull/72.