### PR TITLE
Don't let pkg-config add system lib dirs to the search path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,9 +28,18 @@ fn main() {
        !target.contains("msvc") && // pkg-config just never works here
        !(host_and_target_contain("apple") ||
          host_and_target_contain("freebsd") ||
-         host_and_target_contain("dragonfly")) &&
-        pkg_config::Config::new().cargo_metadata(true).probe("zlib").is_ok() {
-        return
+         host_and_target_contain("dragonfly"))
+    {
+        // Don't print system lib dirs to cargo since this interferes with other
+        // packages adding non-system search paths to link against libraries
+        // that are also found in a system-wide lib dir.
+        let zlib = pkg_config::Config::new()
+            .cargo_metadata(true)
+            .print_system_libs(false)
+            .probe("zlib");
+        if zlib.is_ok() {
+            return;
+        }
     }
 
     if target.contains("msvc") {


### PR DESCRIPTION
Adding system-wide library directories to the linker search path causes these
directories to be searched before other paths added by later crates. If a
library is present in the system-wide directory and a later crate wants to
specifically link against a different version of that library in another path,
the linker will choose the library from the first search directory it
finds. If the linker doesn't find a library in any of the specified search
directories, it falls back on system-wide paths, so we don't need to print the
path we found zlib in if it is in one of those system paths.

This resolves issue #49.