### PR TITLE
Enable shared building on musl

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -58,7 +58,6 @@ fn main() {
         target.contains("pc-windows-gnu") ||
         want_static ||
         target != host ||
-        target.contains("musl")
     {
         return build_zlib(&mut cfg, &target);
     }


### PR DESCRIPTION
I'm honestly unsure why that automagic in there is even needed, we have a `static` feature to set this, or if we can't find anything via pkg-config we'll do static linking anyway with the vendored version so this just limits the choice users have.