### PR TITLE
make static build compatible with cmake

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -91,9 +91,9 @@ fn main() {
 
 fn build_zlib(cfg: &mut cc::Build, target: &str) {
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    let build = dst.join("build");
+    let lib = dst.join("lib");
 
-    cfg.warnings(false).out_dir(&build).include("src/zlib");
+    cfg.warnings(false).out_dir(&lib).include("src/zlib");
 
     cfg.file("src/zlib/adler32.c")
         .file("src/zlib/compress.c")
@@ -131,15 +131,13 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
 
     cfg.compile("z");
 
-    let lib = dst.join("lib");
-    fs::create_dir_all(lib.join("pkgconfig")).unwrap();
     fs::create_dir_all(dst.join("include")).unwrap();
     fs::copy("src/zlib/zlib.h", dst.join("include/zlib.h")).unwrap();
     fs::copy("src/zlib/zconf.h", dst.join("include/zconf.h")).unwrap();
-    fs::rename(build.join("libz.a"), lib.join("libz.a")).unwrap();
 
+    fs::create_dir_all(lib.join("pkgconfig")).unwrap();
     fs::write(
-        dst.join("lib/pkgconfig/zlib.pc"),
+        lib.join("pkgconfig/zlib.pc"),
         fs::read_to_string("src/zlib/zlib.pc.in")
             .unwrap()
             .replace("@prefix@", dst.to_str().unwrap()),

--- a/build.rs
+++ b/build.rs
@@ -140,10 +140,12 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
 
     cfg.compile("z");
 
-    fs::create_dir_all(dst.join("lib/pkgconfig")).unwrap();
+    let lib = dst.join("lib");
+    fs::create_dir_all(lib.join("pkgconfig")).unwrap();
     fs::create_dir_all(dst.join("include")).unwrap();
     fs::copy("src/zlib/zlib.h", dst.join("include/zlib.h")).unwrap();
     fs::copy("src/zlib/zconf.h", dst.join("include/zconf.h")).unwrap();
+    fs::rename(build.join("libz.a"), lib.join("libz.a")).unwrap();
 
     fs::write(
         dst.join("lib/pkgconfig/zlib.pc"),
@@ -153,6 +155,7 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
     ).unwrap();
 
     println!("cargo:root={}", dst.to_str().unwrap());
+    println!("cargo:rustc-link-search=native={}", lib.to_str().unwrap());
     println!("cargo:include={}/include", dst.to_str().unwrap());
 }
 


### PR DESCRIPTION
Common cmake script uses builtin `FindZLIB` module to find where zlib is
installed. The cmake crate allows `register_dep` to hint cmake to search
the right place. libz-sys puts the library under build directory, which
is however not the place where cmake is going to search. So this PR
corrects the behavior by moving the built library to lib directory.

Another option is to set the root directory to build instead, but the
layout may not look good.

It has been an issue for downstream projects like tikv/rust-rocksdb#303
and tikv/grpc-rs#419.