### PR TITLE
Allow building zlib without libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ categories = ["external-ffi-bindings"]
 [workspace]
 members = ["systest"]
 
-[dependencies]
-libc = "0.2.43"
-
 [build-dependencies]
 pkg-config = "0.3.9"
 cc = "1.0.18"
@@ -27,9 +24,16 @@ cc = "1.0.18"
 vcpkg = "0.2"
 
 [features]
+default = ["libc"]
 # When building from source, enable building optimized assembly routines. As
 # noted in `contrib/README.contrib`, these routines are experimental and not
 # vetted, use at your own risk!
 asm = []
 # Enable this feature if you want to have a staticly linked libz
 static = []
+# When this feature is disabled, zlib will be built in Z_SOLO mode which
+# removes dependency on any external libraries like libc at the cost of
+# eliminating some high-level functions like gz*, compress* and
+# uncompress, and requiring embedder to provide memory allocation
+# routines to deflate and inflate.
+libc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,14 @@ categories = ["external-ffi-bindings"]
 [workspace]
 members = ["systest"]
 
+[dependencies]
+# When this feature is disabled, zlib will be built in Z_SOLO mode which
+# removes dependency on any external libraries like libc at the cost of
+# eliminating some high-level functions like gz*, compress* and
+# uncompress, and requiring embedder to provide memory allocation
+# routines to deflate and inflate.
+libc = { version = "0.2.43", optional = true }
+
 [build-dependencies]
 pkg-config = "0.3.9"
 cc = "1.0.18"
@@ -31,9 +39,3 @@ default = ["libc"]
 asm = []
 # Enable this feature if you want to have a staticly linked libz
 static = []
-# When this feature is disabled, zlib will be built in Z_SOLO mode which
-# removes dependency on any external libraries like libc at the cost of
-# eliminating some high-level functions like gz*, compress* and
-# uncompress, and requiring embedder to provide memory allocation
-# routines to deflate and inflate.
-libc = []

--- a/build.rs
+++ b/build.rs
@@ -90,10 +90,6 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
         .file("src/zlib/compress.c")
         .file("src/zlib/crc32.c")
         .file("src/zlib/deflate.c")
-        .file("src/zlib/gzclose.c")
-        .file("src/zlib/gzlib.c")
-        .file("src/zlib/gzread.c")
-        .file("src/zlib/gzwrite.c")
         .file("src/zlib/infback.c")
         .file("src/zlib/inffast.c")
         .file("src/zlib/inflate.c")
@@ -101,6 +97,17 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
         .file("src/zlib/trees.c")
         .file("src/zlib/uncompr.c")
         .file("src/zlib/zutil.c");
+
+    if !cfg!(feature = "libc") || target == "wasm32-unknown-unknown" {
+        cfg.define("Z_SOLO", None);
+    } else {
+        cfg
+        .file("src/zlib/gzclose.c")
+        .file("src/zlib/gzlib.c")
+        .file("src/zlib/gzread.c")
+        .file("src/zlib/gzwrite.c");
+    }
+
     if !target.contains("windows") {
         cfg.define("STDC", None);
         cfg.define("_LARGEFILE64_SOURCE", None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/libz-sys/1.0")]
 #![allow(non_camel_case_types)]
 
-extern crate libc;
-
-use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
+use std::os::raw::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
 pub type alloc_func = unsafe extern fn (voidpf, uInt, uInt) -> voidpf;
 pub type Bytef = u8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ pub type voidpf = *mut c_void;
 pub enum gzFile_s {}
 pub enum internal_state {}
 
-#[cfg(unix)] pub type z_off_t = libc::off_t;
-#[cfg(not(unix))] pub type z_off_t = c_long;
+#[cfg(all(unix, feature = "libc"))] pub type z_off_t = libc::off_t;
+#[cfg(not(all(unix, feature = "libc")))] pub type z_off_t = c_long;
 
 #[repr(C)]
 #[derive(Copy, Clone)]


### PR DESCRIPTION

Adds a `libc` feature which is enabled by default, but opting out from it allows to build zlib with Z_SOLO mode.

This mode removes dependency on any external libraries including libc at the cost of eliminating some high-level functions like gz*, compress* and uncompress, and requiring embedder to provide memory allocation routines to deflate and inflate.

This is useful for targets without libc support such as embedded targets or wasm32-unknown-unknown, as well as for embedding in crates that provide own allocation anyway.

An an example of the latter, when using this mode from a local branch of flate2, the output artifact of `cargo build --release --example compress_file --features zlib` in flate2 goes down by 7KB, even though all the functionality is still available as before.

Note: the reason we're introducing a feature `libc` and not a more natural variant `solo` is because Cargo takes features from all dependencies into the account. That way, if we had at least one dependency that uses libz-sys with `solo` feature, then all other dependencies would also get a Z_SOLO build, which might break their expectations if they depend on other high-level functions. Instead, by providing a `libc` feature, we guarantee that we build in Z_SOLO mode only if none of the dependencies needs the full zlib. For that, all such dependencies must use `default-features = false`.

This build also removes a dependency on the Rust libc crate, because otherwise we would need to disable it conditionally per-target, even though we only need types available in standard library under `std::os::raw` and using them allows to get rid of one more dependency altogether.