### PR TITLE
Add support for zlib-ng

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/zlib"]
 	path = src/zlib
 	url = https://github.com/madler/zlib
+[submodule "src/zlib-ng"]
+	path = src/zlib-ng
+	url = https://github.com/zlib-ng/zlib-ng

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: rust
 matrix:
   include:
     - rust: stable
+    - env: F=zlib-ng
+      rust: stable
     - os: osx
+    - env: F=zlib-ng
+      os: osx
 
     - env: LIBZ_SYS_STATIC=1
     - env: LIBZ_SYS_STATIC=1
@@ -14,10 +18,15 @@ matrix:
         - ci/run-docker.sh
 
     - rust: beta
+    - env: F=zlib-ng
+      rust: beta
+
     - rust: nightly
+    - env: F=zlib-ng
+      rust: nightly
 script:
-  - cargo test
-  - cargo run --manifest-path systest/Cargo.toml
+  - cargo test ${F:+--no-default-features} ${F:+--features} $F
+  - cargo run --manifest-path systest/Cargo.toml ${F:+--features} $F
 notifications:
   email:
     on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.0.27"
+version = "1.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
 links = "z"
 build = "build.rs"
@@ -11,6 +11,7 @@ description = """
 Low-level bindings to the system libz library (also known as zlib).
 """
 categories = ["compression", "external-ffi-bindings"]
+keywords = ["zlib", "zlib-ng"]
 
 [workspace]
 members = ["systest"]
@@ -26,12 +27,34 @@ libc = { version = "0.2.43", optional = true }
 [build-dependencies]
 pkg-config = "0.3.9"
 cc = "1.0.18"
+cmake = { version = "0.1.44", optional = true }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"
 
 [features]
-default = ["libc"]
+default = ["libc", "stock-zlib"]
+# By default, libz-sys uses stock zlib. If you set default-features=false,
+# enable the zlib-ng feature, and don't enable the stock-zlib feature, libz-sys
+# will instead supply the high-performance zlib-ng, in zlib-compat mode. Any
+# application or library designed for zlib should work with zlib-ng in
+# zlib-compat mode, as long as it doesn't make assumptions about the exact size
+# or output of the deflated data (e.g. "compressing this data produces exactly
+# this many bytes"), and as long as you don't also dynamically pull in a copy
+# of stock zlib (which will produce conflicting symbols). If a single crate in
+# the dependency graph requests stock-zlib (or doesn't disable default
+# features), you'll get stock zlib.
+#
+# Library crates should use:
+# libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
+# (Omit the libc feature if you don't require the corresponding functions.)
+#
+# This allows higher-level crates depending on your library to opt into zlib-ng
+# if desired.
+#
+# Building zlib-ng requires cmake.
+zlib-ng =  ["libc", "cmake"]
+stock-zlib = []
 # Deprecated: the assembly routines are outdated, and either reduce performance
 # or cause segfaults.
 asm = []

--- a/README.md
+++ b/README.md
@@ -11,6 +11,34 @@ safe API to work with DEFLATE, zlib, or gzip streams, see
 [`flate2`](https://docs.rs/flate2). `flate2` also supports alternative
 implementations, including slower but pure Rust implementations.
 
+# zlib-ng
+
+This crate supports building either the high-performance zlib-ng (in
+zlib-compat mode), or the widely available stock zlib.
+
+By default, `libz-sys` uses stock zlib, primarily because doing so allows the
+use of a shared system zlib library if available.
+
+Any application or library designed for zlib should work with zlib-ng in
+zlib-compat mode, as long as it doesn't make assumptions about the exact size
+or output of the deflated data (e.g. "compressing this data produces exactly
+this many bytes"), and as long as you don't also dynamically pull in a copy of
+stock zlib (which will produce conflicting symbols). Nonetheless, for maximum
+compatibility, every library crate in a build must opt into allowing zlib-ng;
+if any library crate in your dependency graph wants stock zlib, `libz-sys` will
+use stock zlib.
+
+Library crates depending on `libz-sys` should use:
+```
+libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
+```
+(Omit the `libc` feature if you don't require the corresponding functions.)
+
+This allows higher-level crates depending on your library to opt into zlib-ng
+if desired.
+
+Building zlib-ng requires `cmake`.
+
 # License
 
 This project is licensed under either of

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,20 @@ environment:
   matrix:
   - TARGET: x86_64-pc-windows-gnu
     MSYS_BITS: 64
+  - TARGET: x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+    FEAT: zlib-ng
   - TARGET: i686-pc-windows-gnu
     MSYS_BITS: 32
+  - TARGET: i686-pc-windows-gnu
+    MSYS_BITS: 32
+    FEAT: zlib-ng
   - TARGET: x86_64-pc-windows-msvc
+  - TARGET: x86_64-pc-windows-msvc
+    FEAT: zlib-ng
   - TARGET: i686-pc-windows-msvc
+  - TARGET: i686-pc-windows-msvc
+    FEAT: zlib-ng
   - TARGET: x86_64-pc-windows-msvc
     VCPKG_DEFAULT_TRIPLET: x64-windows-static
     RUSTFLAGS: -Ctarget-feature=+crt-static
@@ -26,5 +36,7 @@ install:
 build: false
 
 test_script:
-  - cargo test --target %TARGET%
-  - cargo run --manifest-path systest/Cargo.toml --target %TARGET%
+  - if not defined FEAT cargo test --target %TARGET%
+  - if not defined FEAT cargo run --manifest-path systest/Cargo.toml --target %TARGET%
+  - if defined FEAT cargo test --target %TARGET% --no-default-features --features %FEAT%
+  - if defined FEAT cargo run --manifest-path systest/Cargo.toml --target %TARGET% --features %FEAT%

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,12 @@ fn main() {
 
     let host_and_target_contain = |s| host.contains(s) && target.contains(s);
 
+    let want_ng = cfg!(feature = "zlib-ng") && !cfg!(feature = "stock-zlib");
+
+    if want_ng && target != "wasm32-unknown-unknown" {
+        return build_zlib_ng();
+    }
+
     // Don't run pkg-config if we're linking statically (we'll build below) and
     // also don't run pkg-config on macOS/FreeBSD/DragonFly. That'll end up printing
     // `-L /usr/lib` which wreaks havoc with linking to an OpenSSL in /usr/local/lib
@@ -140,6 +146,24 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
 
     println!("cargo:root={}", dst.to_str().unwrap());
     println!("cargo:include={}/include", dst.to_str().unwrap());
+}
+
+#[cfg(not(feature = "zlib-ng"))]
+fn build_zlib_ng() {}
+
+#[cfg(feature = "zlib-ng")]
+fn build_zlib_ng() {
+    let install_dir = cmake::Config::new("src/zlib-ng")
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .define("ZLIB_COMPAT", "ON")
+        .define("WITH_GZFILEOP", "ON")
+        .build();
+    let includedir = install_dir.join("include");
+    let libdir = install_dir.join("lib");
+    println!("cargo:rustc-link-search=native={}", libdir.to_str().unwrap());
+    println!("cargo:rustc-link-lib=z");
+    println!("cargo:root={}", install_dir.to_str().unwrap());
+    println!("cargo:include={}", includedir.to_str().unwrap());
 }
 
 #[cfg(not(target_env = "msvc"))]

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 
 [dependencies]
-libz-sys = { path = ".." }
+libz-sys = { path = "..", default-features = false, features = ["libc"] }
 libc = "0.2"
 
 [build-dependencies]
@@ -13,3 +13,4 @@ ctest = "0.1"
 
 [features]
 libz-static = ["libz-sys/static"]
+zlib-ng = ["libz-sys/zlib-ng"]

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -20,5 +20,6 @@ fn main() {
         | "in_func" | "free_func" | "alloc_func" | "z_streamp" => true,
         _ => false,
     });
+    cfg.skip_field_type(|s, field| s == "z_stream" && (field == "next_in" || field == "msg"));
     cfg.generate("../src/lib.rs", "all.rs");
 }


### PR DESCRIPTION
Add support for building libz-sys using zlib-ng in zlib-compat mode.

By default, `libz-sys` still uses stock zlib, primarily because doing so allows the use of a shared system zlib library if available.

Any application or library designed for zlib should work with zlib-ng in zlib-compat mode, as long as it doesn't make assumptions about the exact size or output of the deflated data (e.g. "compressing this data produces exactly this many bytes"), and as long as you don't also dynamically pull in a copy of stock zlib (which will produce conflicting symbols). Nonetheless, for maximum compatibility, every library crate in a build must opt into allowing zlib-ng; if any library crate in your dependency graph wants stock zlib, `libz-sys` will use stock zlib.

Library crates depending on `libz-sys` should use:
```
libz-sys = { version = "1.1.0", default-features = false, features = ["libc"] }
```
(Omit the `libc` feature if you don't require the corresponding functions.)

This allows higher-level crates depending on your library to opt into zlib-ng if desired.

Building zlib-ng requires `cmake`. zlib-ng requires building different files with different optimization options, and the `cc` crate doesn't support that: https://github.com/alexcrichton/cc-rs/issues/545