### PR TITLE
Use `ctest2` instead of the original to fix warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,5 @@ stock-zlib = []
 # Deprecated: the assembly routines are outdated, and either reduce performance
 # or cause segfaults.
 asm = []
-# Enable this feature if you want to have a staticly linked libz
+# Enable this feature if you want to have a statically linked libz
 static = []

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -9,7 +9,7 @@ libz-sys = { path = "..", default-features = false, features = ["libc"] }
 libc = "0.2"
 
 [build-dependencies]
-ctest = "0.1"
+ctest2 = "0.3"
 
 [features]
 libz-static = ["libz-sys/static"]

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -1,14 +1,14 @@
-extern crate ctest;
+extern crate ctest2;
 
 use std::env;
 
 fn main() {
-    let mut cfg = ctest::TestGenerator::new();
+    let mut cfg = ctest2::TestGenerator::new();
     cfg.header("zlib.h");
     if let Some(s) = env::var_os("DEP_Z_INCLUDE") {
         cfg.include(s);
     }
-    cfg.type_name(|n, _| {
+    cfg.type_name(|n, _, _| {
         if n == "internal_state" {
             format!("struct {}", n)
         } else {


### PR DESCRIPTION
I saw Josh opened this issue: https://github.com/gnzlbg/ctest/issues/99
That's because we use ctest v0.1 here, it's outdated a bit. We could fix this issue by updating it to v0.2 but it will emit uninitialized errors, like this: https://github.com/JohnTitor/libz-sys/runs/1014401885
So, if you want to get rid of the warnings, I'd recommend using ctest2, which is a fork of ctest and has some fixes: https://github.com/JohnTitor/ctest2
I created this to use on the libc crate, but I hope this helps here as well :)
