### PR TITLE
Haiku: always link to the system libz.so.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,8 +53,9 @@ fn main() {
     }
 
     // All android compilers should come with libz by default, so let's just use
-    // the one already there.
-    if target.contains("android") {
+    // the one already there. Likewise, Haiku always ships with libz, so we can
+    // link to it even when cross-compiling.
+    if target.contains("android") || target.contains("haiku") {
         println!("cargo:rustc-link-lib=z");
         return;
     }


### PR DESCRIPTION
When rustc and cargo are built for Haiku, they are cross-compiled from Linux.
The current logic of the build script decides to build from source when
cross-compiling. On Haiku, this is unnecessary. We can safely assume that
libz.so is on the target system. Therefore, like with Android, we can always
link to it.