### PR TITLE
Disable forced zlib vendoring on musl

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,6 @@ fn main() {
         || target.contains("pc-windows-gnu")
         || want_static
         || target != host
-        || target.contains("musl")
     {
         return build_zlib(&mut cfg, &target);
     }


### PR DESCRIPTION
I use Void Linux with `musl` as system libc (I don't use glibc at all). I'm trying to make a package for [wezterm](https://github.com/wez/wezterm). `wezterm` depends on `libz-sys`, and it fails to build because it tries to build `zlib` from source and it obviously doesn't find them.

So I suggest removing this hardcoded vendoring for musl, because your assumptions about musl being used for embedded statically build stuff is wrong. There are at least 3 distros from top of my mind which use musl: Void Linux, Alpine Linux, Adélie Linux.

Another option would be downloading `zlib` or `zlib-ng` sources tarball, unpacking it into the right location before starting to build `wezterm`. But it seems hacky and harder than removing single line from `libz-sys`'s `build.rs`.

See also: https://github.com/rust-lang/libz-sys/pull/54