### PR TITLE
Darwin: don't build zlib if universal binaries are available

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -66,11 +66,11 @@ fn main() {
     //
     // MSVC basically never has it preinstalled, MinGW picks up a bunch of weird
     // paths we don't like, `want_static` may force us, and cross compiling almost
-    // never has a prebuilt version.
+    // never has a prebuilt version, unless system supports "universal" binaries as macOS does.
     if target.contains("msvc")
         || target.contains("pc-windows-gnu")
         || want_static
-        || target != host
+        || (target != host && !host_and_target_contain("darwin"))
     {
         return build_zlib(&mut cfg, &target);
     }


### PR DESCRIPTION
A 32-bit build on a 64-bit macOS system is considered cross compiling.
However, macOS supports "universal" binaries, so prebuilt binaries *are* installed.
The same is true of x86_64 build on a aarch64 macOS system.