### PR TITLE
Use the latest build deps to fix builds on windows-2022

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ members = ["systest"]
 libc = { version = "0.2.43", optional = true }
 
 [build-dependencies]
-pkg-config = "0.3.9"
-cc = "1.0.18"
-cmake = { version = "0.1.44", optional = true }
+pkg-config = "0.3.24"
+cc = "1.0.73"
+cmake = { version = "0.1.48", optional = true }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"


### PR DESCRIPTION
Should fix https://github.com/rust-lang/libz-sys/issues/86