### PR TITLE
build.rs: Fix library name on Windows, with and without MSVC

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -183,11 +183,11 @@ fn build_zlib_ng(target: &str) {
         "cargo:rustc-link-search=native={}",
         libdir.to_str().unwrap()
     );
-    let libname = if target.contains("windows") {
-        if target.contains("msvc") && env::var("OPT_LEVEL").unwrap() == "0" {
-            "zlibd"
+    let libname = if target.contains("windows") && target.contains("msvc") {
+        if env::var("OPT_LEVEL").unwrap() == "0" {
+            "zlibstaticd"
         } else {
-            "zlib"
+            "zlibstatic"
         }
     } else {
         "z"


### PR DESCRIPTION
Current zlib-ng uses "zlibstatic" for the static library on MSVC Windows
only, and uses just "z" for non-MSVC Windows targets.
