### PR TITLE
Fix build on macOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -174,6 +174,9 @@ fn build_zlib_ng(target: &str) {
             .define("WITH_DFLTCC_INFLATE", "1")
             .cflag("-DDFLTCC_LEVEL_MASK=0x7e");
     }
+    if target.contains("apple") {
+        cmake.cflag("-D_DARWIN_C_SOURCE=1");
+    }
 
     let install_dir = cmake.build();
 


### PR DESCRIPTION
Current zlib-ng defines _POSIX_C_SOURCE, which causes macOS sys/types.h
to not define types like u_char and u_int, which leads to compilation
errors when including other headers that use those types.

Define _DARWIN_C_SOURCE to work around this, which causes macOS
sys/types.h to define these types again.
