### PR TITLE
Fix zlib-ng win32 builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -177,6 +177,9 @@ fn build_zlib_ng(target: &str) {
     if target.contains("apple") {
         cmake.cflag("-D_DARWIN_C_SOURCE=1");
     }
+    if target == "i686-pc-windows-msvc" {
+        cmake.define("CMAKE_GENERATOR_PLATFORM", "Win32");
+    }
 
     let install_dir = cmake.build();
 


### PR DESCRIPTION
I'm pretty sure this is the correct way to set this; it seems to pass CI anyway.  Not really an area I'm an expert in...  If there's a better way to do this lmk.