### PR TITLE
Fix static wasm build without wasi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,11 @@ pub type voidpf = *mut c_void;
 pub enum gzFile_s {}
 pub enum internal_state {}
 
-#[cfg(feature = "libc")]
+#[cfg(all(feature = "libc", not(all(target_family = "wasm", target_os = "unknown"))))]
 pub type z_off_t = libc::off_t;
+
+#[cfg(all(feature = "libc", all(target_family = "wasm", target_os = "unknown")))]
+pub type z_off_t = c_long;
 
 #[repr(C)]
 #[derive(Copy, Clone)]


### PR DESCRIPTION
`libc` doesn't have `off_t` for WebAssembly without WASI, so it falls
back to `long`.  Do the same in this crate to fix the build error when
trying to statically build libz for WebAssembly.

Rough code from `zconf.h` declaring `z_off_t`:
```c++
#ifndef Z_SOLO
#  if defined(Z_HAVE_UNISTD_H) || defined(_LARGEFILE64_SOURCE)
// [...]
#    ifndef z_off_t
#      define z_off_t off_t
#    endif
#  endif
#endif

// [...]

#ifndef z_off_t
#  define z_off_t long
#endif
```

Fixes #95.