### PR TITLE
Update zlib-ng to fix segfault due to unaligned access

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -166,6 +166,7 @@ fn build_zlib_ng(target: &str) {
     cmake
         .define("BUILD_SHARED_LIBS", "OFF")
         .define("ZLIB_COMPAT", "ON")
+        .define("ZLIB_ENABLE_TESTS", "OFF")
         .define("WITH_GZFILEOP", "ON");
     if target.contains("s390x") {
         // Enable hardware compression on s390x.


### PR DESCRIPTION
zlib-ng commit a39e323a4db80a57feecf2ae212c08070234050c ("Added memory alignment compensation functions for users who may be using custom allocators that don't align on the same boundary zlib-ng expects.") fixes the segfault.

Update zlib-ng to the latest version that passes flate2's testsuite.

Also, prevent the zlib-ng build process from touching the network, by not building the zlib-ng testsuite (which we don't invoke). This will improve build time as well.