### PR TITLE
Add a libz-ng-sys crate, using the same sources with minimal duplication

### DIFF
--- a/Cargo-zng.toml
+++ b/Cargo-zng.toml
@@ -1,0 +1,35 @@
+[package]
+name = "libz-ng-sys"
+version = "1.1.7"
+authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
+links = "z-ng"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/libz-sys"
+description = "Low-level bindings to zlib-ng (libz-ng), a high-performance zlib library."
+categories = ["compression", "external-ffi-bindings"]
+keywords = ["zlib", "zlib-ng"]
+edition = "2018"
+
+exclude = [
+    "/.github",
+    "/.gitmodules",
+    "/README.md",
+    "/build.rs",
+    "/cargo-zng",
+    "/ci",
+    "/src/smoke.c",
+    "/src/zlib",
+    "/systest",
+]
+
+build = "build_zng.rs"
+readme = "README-zng.md"
+
+[workspace]
+members = ["systest"]
+
+[dependencies]
+libc = "0.2.43"
+
+[build-dependencies]
+cmake = "0.1.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.1.6"
+version = "1.1.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
 links = "z"
 license = "MIT OR Apache-2.0"
@@ -9,6 +9,15 @@ description = "Low-level bindings to the system libz library (also known as zlib
 categories = ["compression", "external-ffi-bindings"]
 keywords = ["zlib", "zlib-ng"]
 edition = "2018"
+
+exclude = [
+    "/.github",
+    "/.gitmodules",
+    "/Cargo-zng.toml",
+    "/cargo-zng",
+    "/ci",
+    "/systest"
+]
 
 [workspace]
 members = ["systest"]

--- a/README-zng.md
+++ b/README-zng.md
@@ -1,0 +1,41 @@
+# libz-ng-sys
+
+A library for linking zlib-ng (`libz-ng`) to Rust programs natively, rather
+than in zlib-compat mode.
+
+zlib-ng is a high-performance implementation of zlib. zlib-ng supports building
+in two modes: zlib-compat mode, in whih it provides the same API as zlib and
+generally works as a drop-in replacement, and native mode, in which it provides
+its own API. The native API is almost identical to the zlib-compat API, except
+that some types use more correct sizes (rather than the sizes required for zlib
+compatibility), and the functions all have a `zng_` prefix. The latter allows
+zlib and zlib-ng to coexist in the same program.
+
+This crate provides bindings to the native zlib-ng API. However, for simplicity
+of porting, this crate exports the same API as libz-sys (without the `zng_`
+prefixes), making it easier to write Rust software compatible with both
+libz-sys and libz-ng-sys.
+
+# High-level API
+
+This crate provides bindings to the raw low-level C API. For a higher-level
+safe API to work with DEFLATE, zlib, or gzip streams, see
+[`flate2`](https://docs.rs/flate2). `flate2` supports many different
+implementations.
+
+# License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A common library for linking `libz` to rust programs (also known as zlib).
 
 [Documentation](https://docs.rs/libz-sys)
 
+This also serves as the source for the `libz-ng-sys` crate, which builds
+zlib-ng natively (not in zlib-compat mode). See
+[`README-zng.md`](README-zng.md) for details.
+
 # High-level API
 
 This crate provides bindings to the raw low-level C API. For a higher-level

--- a/build_zng.rs
+++ b/build_zng.rs
@@ -1,0 +1,58 @@
+use std::env;
+
+pub fn build_zlib_ng(target: &str, compat: bool) {
+    let mut cmake = cmake::Config::new("src/zlib-ng");
+    cmake
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .define("ZLIB_COMPAT", if compat { "ON" } else { "OFF" })
+        .define("ZLIB_ENABLE_TESTS", "OFF")
+        .define("WITH_GZFILEOP", "ON");
+    if target.contains("s390x") {
+        // Enable hardware compression on s390x.
+        cmake
+            .define("WITH_DFLTCC_DEFLATE", "1")
+            .define("WITH_DFLTCC_INFLATE", "1")
+            .cflag("-DDFLTCC_LEVEL_MASK=0x7e");
+    }
+    if target.contains("apple") {
+        cmake.cflag("-D_DARWIN_C_SOURCE=1");
+    }
+    if target == "i686-pc-windows-msvc" {
+        cmake.define("CMAKE_GENERATOR_PLATFORM", "Win32");
+    }
+
+    let install_dir = cmake.build();
+
+    let includedir = install_dir.join("include");
+    let libdir = install_dir.join("lib");
+    println!(
+        "cargo:rustc-link-search=native={}",
+        libdir.to_str().unwrap()
+    );
+    let mut debug_suffix = "";
+    let libname = if target.contains("windows") && target.contains("msvc") {
+        if env::var("OPT_LEVEL").unwrap() == "0" {
+            debug_suffix = "d";
+        }
+        "zlibstatic"
+    } else {
+        "z"
+    };
+    println!(
+        "cargo:rustc-link-lib=static={}{}{}",
+        libname,
+        if compat { "" } else { "-ng" },
+        debug_suffix,
+    );
+    println!("cargo:root={}", install_dir.to_str().unwrap());
+    println!("cargo:include={}", includedir.to_str().unwrap());
+    if !compat {
+        println!("cargo:rustc-cfg=zng");
+    }
+}
+
+#[allow(dead_code)]
+fn main() {
+    let target = env::var("TARGET").unwrap();
+    build_zlib_ng(&target, false);
+}

--- a/cargo-zng
+++ b/cargo-zng
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu
+trap 'rm -rf "$tempdir"' 0 INT
+tempdir="$(mktemp -d)"
+cargo package -l --allow-dirty | grep -v '^Cargo\.toml\.orig$' | tar --verbatim-files-from --files-from=- -cf - | tar -C "$tempdir" -xf -
+cp Cargo-zng.toml "$tempdir/Cargo.toml"
+cp -a systest "$tempdir/systest"
+mv "$tempdir/systest/Cargo-zng.toml" "$tempdir/systest/Cargo.toml"
+cd "$tempdir"
+cargo "$@"

--- a/ci/test.bash
+++ b/ci/test.bash
@@ -33,4 +33,9 @@ $CROSS test --target $TARGET_TRIPLE
 $CROSS run --target $TARGET_TRIPLE --manifest-path systest/Cargo.toml
 echo === zlib-ng build ===
 $CROSS test --target $TARGET_TRIPLE --no-default-features --features zlib-ng
-$CROSS run --target $TARGET_TRIPLE --manifest-path systest/Cargo.toml  --no-default-features --features zlib-ng
+$CROSS run --target $TARGET_TRIPLE --manifest-path systest/Cargo.toml --no-default-features --features zlib-ng
+echo === libz-ng-sys build ===
+mv Cargo-zng.toml Cargo.toml
+mv systest/Cargo-zng.toml systest/Cargo.toml
+$CROSS test --target $TARGET_TRIPLE
+$CROSS run --target $TARGET_TRIPLE --manifest-path systest/Cargo.toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,32 @@
 
 use std::os::raw::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 
+// Macro for variances between zlib-ng in native mode and either zlib or zlib-ng in zlib compat
+// mode. Note in particular that zlib-ng in compat mode does *not* use the zng case.
+#[cfg(not(zng))]
+macro_rules! if_zng {
+    ($_zng:tt, $not_zng:tt) => {
+        $not_zng
+    };
+}
+
+#[cfg(zng)]
+macro_rules! if_zng {
+    ($zng:tt, $_not_zng:tt) => {
+        $zng
+    };
+}
+
+// zlib uses unsigned long for various sizes; zlib-ng uses size_t.
+type z_size = if_zng!(usize, c_ulong);
+
+// zlib stores Adler-32 and CRC-32 checksums in unsigned long; zlib-ng uses uint32_t.
+type z_checksum = if_zng!(u32, c_ulong);
+
 pub type alloc_func = unsafe extern "C" fn(voidpf, uInt, uInt) -> voidpf;
 pub type Bytef = u8;
 pub type free_func = unsafe extern "C" fn(voidpf, voidpf);
-#[cfg(feature = "libc")]
+#[cfg(any(zng, feature = "libc"))]
 pub type gzFile = *mut gzFile_s;
 pub type in_func = unsafe extern "C" fn(*mut c_void, *mut *const c_uchar) -> c_uint;
 pub type out_func = unsafe extern "C" fn(*mut c_void, *mut c_uchar, c_uint) -> c_int;
@@ -16,18 +38,26 @@ pub type voidp = *mut c_void;
 pub type voidpc = *const c_void;
 pub type voidpf = *mut c_void;
 
-#[cfg(feature = "libc")]
+#[cfg(any(zng, feature = "libc"))]
 pub enum gzFile_s {}
 pub enum internal_state {}
 
 #[cfg(all(
+    not(zng),
     feature = "libc",
     not(all(target_family = "wasm", target_os = "unknown"))
 ))]
 pub type z_off_t = libc::off_t;
 
-#[cfg(all(feature = "libc", all(target_family = "wasm", target_os = "unknown")))]
+#[cfg(all(
+    not(zng),
+    feature = "libc",
+    all(target_family = "wasm", target_os = "unknown")
+))]
 pub type z_off_t = c_long;
+
+#[cfg(zng)]
+pub type z_off_t = i64;
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -53,34 +83,55 @@ pub type gz_headerp = *mut gz_header;
 pub struct z_stream {
     pub next_in: *mut Bytef,
     pub avail_in: uInt,
-    pub total_in: uLong,
+    pub total_in: z_size,
     pub next_out: *mut Bytef,
     pub avail_out: uInt,
-    pub total_out: uLong,
+    pub total_out: z_size,
     pub msg: *mut c_char,
     pub state: *mut internal_state,
     pub zalloc: alloc_func,
     pub zfree: free_func,
     pub opaque: voidpf,
     pub data_type: c_int,
-    pub adler: uLong,
+    pub adler: z_checksum,
     pub reserved: uLong,
 }
 pub type z_streamp = *mut z_stream;
 
+// Ideally, this should instead use a macro that parses the whole block of externs, and generates
+// the appropriate link_name attributes, without duplicating the function names. However, ctest2
+// can't parse that.
+#[cfg(not(zng))]
+macro_rules! zng_prefix {
+    ($name:expr) => { stringify!($name) }
+}
+
+#[cfg(zng)]
+macro_rules! zng_prefix {
+    ($name:expr) => { concat!("zng_", stringify!($name)) }
+}
+
 extern "C" {
-    pub fn adler32(adler: uLong, buf: *const Bytef, len: uInt) -> uLong;
-    pub fn crc32(crc: uLong, buf: *const Bytef, len: uInt) -> uLong;
+    #[link_name = zng_prefix!(adler32)]
+    pub fn adler32(adler: z_checksum, buf: *const Bytef, len: uInt) -> z_checksum;
+    #[link_name = zng_prefix!(crc32)]
+    pub fn crc32(crc: z_checksum, buf: *const Bytef, len: uInt) -> z_checksum;
+    #[link_name = zng_prefix!(deflate)]
     pub fn deflate(strm: z_streamp, flush: c_int) -> c_int;
+    #[link_name = zng_prefix!(deflateBound)]
     pub fn deflateBound(strm: z_streamp, sourceLen: uLong) -> uLong;
+    #[link_name = zng_prefix!(deflateCopy)]
     pub fn deflateCopy(dest: z_streamp, source: z_streamp) -> c_int;
+    #[link_name = zng_prefix!(deflateEnd)]
     pub fn deflateEnd(strm: z_streamp) -> c_int;
+    #[link_name = zng_prefix!(deflateInit_)]
     pub fn deflateInit_(
         strm: z_streamp,
         level: c_int,
         version: *const c_char,
         stream_size: c_int,
     ) -> c_int;
+    #[link_name = zng_prefix!(deflateInit2_)]
     pub fn deflateInit2_(
         strm: z_streamp,
         level: c_int,
@@ -91,15 +142,21 @@ extern "C" {
         version: *const c_char,
         stream_size: c_int,
     ) -> c_int;
+    #[link_name = zng_prefix!(deflateParams)]
     pub fn deflateParams(strm: z_streamp, level: c_int, strategy: c_int) -> c_int;
+    #[link_name = zng_prefix!(deflatePrime)]
     pub fn deflatePrime(strm: z_streamp, bits: c_int, value: c_int) -> c_int;
+    #[link_name = zng_prefix!(deflateReset)]
     pub fn deflateReset(strm: z_streamp) -> c_int;
+    #[link_name = zng_prefix!(deflateSetDictionary)]
     pub fn deflateSetDictionary(
         strm: z_streamp,
         dictionary: *const Bytef,
         dictLength: uInt,
     ) -> c_int;
+    #[link_name = zng_prefix!(deflateSetHeader)]
     pub fn deflateSetHeader(strm: z_streamp, head: gz_headerp) -> c_int;
+    #[link_name = zng_prefix!(deflateTune)]
     pub fn deflateTune(
         strm: z_streamp,
         good_length: c_int,
@@ -107,7 +164,9 @@ extern "C" {
         nice_length: c_int,
         max_chain: c_int,
     ) -> c_int;
+    #[link_name = zng_prefix!(inflate)]
     pub fn inflate(strm: z_streamp, flush: c_int) -> c_int;
+    #[link_name = zng_prefix!(inflateBack)]
     pub fn inflateBack(
         strm: z_streamp,
         _in: in_func,
@@ -115,7 +174,9 @@ extern "C" {
         out: out_func,
         out_desc: *mut c_void,
     ) -> c_int;
+    #[link_name = zng_prefix!(inflateBackEnd)]
     pub fn inflateBackEnd(strm: z_streamp) -> c_int;
+    #[link_name = zng_prefix!(inflateBackInit_)]
     pub fn inflateBackInit_(
         strm: z_streamp,
         windowBits: c_int,
@@ -123,28 +184,39 @@ extern "C" {
         version: *const c_char,
         stream_size: c_int,
     ) -> c_int;
+    #[link_name = zng_prefix!(inflateCopy)]
     pub fn inflateCopy(dest: z_streamp, source: z_streamp) -> c_int;
+    #[link_name = zng_prefix!(inflateEnd)]
     pub fn inflateEnd(strm: z_streamp) -> c_int;
+    #[link_name = zng_prefix!(inflateGetHeader)]
     pub fn inflateGetHeader(strm: z_streamp, head: gz_headerp) -> c_int;
+    #[link_name = zng_prefix!(inflateInit_)]
     pub fn inflateInit_(strm: z_streamp, version: *const c_char, stream_size: c_int) -> c_int;
+    #[link_name = zng_prefix!(inflateInit2_)]
     pub fn inflateInit2_(
         strm: z_streamp,
         windowBits: c_int,
         version: *const c_char,
         stream_size: c_int,
     ) -> c_int;
+    #[link_name = zng_prefix!(inflateMark)]
     pub fn inflateMark(strm: z_streamp) -> c_long;
+    #[link_name = zng_prefix!(inflatePrime)]
     pub fn inflatePrime(strm: z_streamp, bits: c_int, value: c_int) -> c_int;
+    #[link_name = zng_prefix!(inflateReset)]
     pub fn inflateReset(strm: z_streamp) -> c_int;
+    #[link_name = zng_prefix!(inflateReset2)]
     pub fn inflateReset2(strm: z_streamp, windowBits: c_int) -> c_int;
+    #[link_name = zng_prefix!(inflateSetDictionary)]
     pub fn inflateSetDictionary(
         strm: z_streamp,
         dictionary: *const Bytef,
         dictLength: uInt,
     ) -> c_int;
+    #[link_name = zng_prefix!(inflateSync)]
     pub fn inflateSync(strm: z_streamp) -> c_int;
+    #[link_name = zng_prefix!(zlibCompileFlags)]
     pub fn zlibCompileFlags() -> uLong;
-    pub fn zlibVersion() -> *const c_char;
 
     // The above set of functions currently target 1.2.3.4 (what's present on Ubuntu
     // 12.04, but there's some other APIs that were added later. Should figure out
@@ -168,48 +240,78 @@ extern "C" {
     //     pub fn gzoffset(file: gzFile) -> z_off_t;
 }
 
-#[cfg(feature = "libc")]
 extern "C" {
-    pub fn adler32_combine(adler1: uLong, adler2: uLong, len2: z_off_t) -> uLong;
+    #[link_name = if_zng!("zlibng_version", "zlibVersion")]
+    pub fn zlibVersion() -> *const c_char;
+}
+
+#[cfg(any(zng, feature = "libc"))]
+extern "C" {
+    #[link_name = zng_prefix!(adler32_combine)]
+    pub fn adler32_combine(adler1: z_checksum, adler2: z_checksum, len2: z_off_t) -> z_checksum;
+    #[link_name = zng_prefix!(compress)]
     pub fn compress(
         dest: *mut Bytef,
-        destLen: *mut uLongf,
+        destLen: *mut z_size,
         source: *const Bytef,
-        sourceLen: uLong,
+        sourceLen: z_size,
     ) -> c_int;
+    #[link_name = zng_prefix!(compress2)]
     pub fn compress2(
         dest: *mut Bytef,
-        destLen: *mut uLongf,
+        destLen: *mut z_size,
         source: *const Bytef,
-        sourceLen: uLong,
+        sourceLen: z_size,
         level: c_int,
     ) -> c_int;
-    pub fn compressBound(sourceLen: uLong) -> uLong;
-    pub fn crc32_combine(crc1: uLong, crc2: uLong, len2: z_off_t) -> uLong;
+    #[link_name = zng_prefix!(compressBound)]
+    pub fn compressBound(sourceLen: z_size) -> z_size;
+    #[link_name = zng_prefix!(crc32_combine)]
+    pub fn crc32_combine(crc1: z_checksum, crc2: z_checksum, len2: z_off_t) -> z_checksum;
+    #[link_name = zng_prefix!(gzdirect)]
     pub fn gzdirect(file: gzFile) -> c_int;
+    #[link_name = zng_prefix!(gzdopen)]
     pub fn gzdopen(fd: c_int, mode: *const c_char) -> gzFile;
+    #[link_name = zng_prefix!(gzclearerr)]
     pub fn gzclearerr(file: gzFile);
+    #[link_name = zng_prefix!(gzclose)]
     pub fn gzclose(file: gzFile) -> c_int;
+    #[link_name = zng_prefix!(gzeof)]
     pub fn gzeof(file: gzFile) -> c_int;
+    #[link_name = zng_prefix!(gzerror)]
     pub fn gzerror(file: gzFile, errnum: *mut c_int) -> *const c_char;
+    #[link_name = zng_prefix!(gzflush)]
     pub fn gzflush(file: gzFile, flush: c_int) -> c_int;
+    #[link_name = zng_prefix!(gzgetc)]
     pub fn gzgetc(file: gzFile) -> c_int;
+    #[link_name = zng_prefix!(gzgets)]
     pub fn gzgets(file: gzFile, buf: *mut c_char, len: c_int) -> *mut c_char;
+    #[link_name = zng_prefix!(gzopen)]
     pub fn gzopen(path: *const c_char, mode: *const c_char) -> gzFile;
+    #[link_name = zng_prefix!(gzputc)]
     pub fn gzputc(file: gzFile, c: c_int) -> c_int;
+    #[link_name = zng_prefix!(gzputs)]
     pub fn gzputs(file: gzFile, s: *const c_char) -> c_int;
+    #[link_name = zng_prefix!(gzread)]
     pub fn gzread(file: gzFile, buf: voidp, len: c_uint) -> c_int;
+    #[link_name = zng_prefix!(gzrewind)]
     pub fn gzrewind(file: gzFile) -> c_int;
+    #[link_name = zng_prefix!(gzseek)]
     pub fn gzseek(file: gzFile, offset: z_off_t, whence: c_int) -> z_off_t;
+    #[link_name = zng_prefix!(gzsetparams)]
     pub fn gzsetparams(file: gzFile, level: c_int, strategy: c_int) -> c_int;
+    #[link_name = zng_prefix!(gztell)]
     pub fn gztell(file: gzFile) -> z_off_t;
+    #[link_name = zng_prefix!(gzungetc)]
     pub fn gzungetc(c: c_int, file: gzFile) -> c_int;
+    #[link_name = zng_prefix!(gzwrite)]
     pub fn gzwrite(file: gzFile, buf: voidpc, len: c_uint) -> c_int;
+    #[link_name = zng_prefix!(uncompress)]
     pub fn uncompress(
         dest: *mut Bytef,
-        destLen: *mut uLongf,
+        destLen: *mut z_size,
         source: *const Bytef,
-        sourceLen: uLong,
+        sourceLen: z_size,
     ) -> c_int;
 }
 

--- a/systest/Cargo-zng.toml
+++ b/systest/Cargo-zng.toml
@@ -1,0 +1,12 @@
+[package]
+name = "systest-zng"
+version = "0.1.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
+edition = "2018"
+
+[dependencies]
+libz-ng-sys = { path = ".." }
+libc = "0.2"
+
+[build-dependencies]
+ctest2 = "0.4.4"

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -2,7 +2,7 @@
 name = "systest"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-build = "build.rs"
+edition = "2018"
 
 [dependencies]
 libz-sys = { path = "..", default-features = false, features = ["libc"] }

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,9 +1,9 @@
 #![allow(bad_style, improper_ctypes)]
 
-extern crate libc;
-extern crate libz_sys;
-
 use libc::*;
+#[cfg(not(zng))]
 use libz_sys::*;
+#[cfg(zng)]
+use libz_ng_sys::*;
 
 include!(concat!(env!("OUT_DIR"), "/all.rs"));


### PR DESCRIPTION
libz-ng-sys uses the zlib-ng native API, rather than the zlib-compat
API. It exports the same Rust API (modulo the slight differences in
types), without the `zng_` prefixes, to make it easy to write Rust
software that works with both.

Add a separate Cargo.toml and README for libz-ng-sys.

Move the `build_zlib_ng` function from `build.rs` to `build_zng.rs`, and
use that as the build script for libz-ng-sys.

Add a cargo-zng script that creates the libz-ng-sys crate in a temporary
directory and runs cargo on it, to make it easy to run tests with:
```
./cargo-zng test
./cargo-zng run --manifest-path systest/Cargo.toml
```

Test libz-ng-sys in CI.
