### PR TITLE
Upgrade to current zlib-ng to get fix for internal symbol collisions

### DIFF
--- a/Cargo-zng.toml
+++ b/Cargo-zng.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-ng-sys"
-version = "1.1.7"
+version = "1.1.8"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
 links = "z-ng"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.1.7"
+version = "1.1.8"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
 links = "z"
 license = "MIT OR Apache-2.0"

--- a/build_zng.rs
+++ b/build_zng.rs
@@ -14,9 +14,6 @@ pub fn build_zlib_ng(target: &str, compat: bool) {
             .define("WITH_DFLTCC_INFLATE", "1")
             .cflag("-DDFLTCC_LEVEL_MASK=0x7e");
     }
-    if target.contains("apple") {
-        cmake.cflag("-D_DARWIN_C_SOURCE=1");
-    }
     if target == "i686-pc-windows-msvc" {
         cmake.define("CMAKE_GENERATOR_PLATFORM", "Win32");
     }


### PR DESCRIPTION
Now that upstream has commit 84f116a3d782b39047b666bc6804e2c0c2138e6d,
we are no longer blocked from upgrading.

We want commit 9be98893aaf69892811d617122e28ea2dd8e17ba, to avoid
conflicts between zlib and zlib-ng when building in native mode (for
libz-ng-sys).

Also, thanks to commit d41f8ead569ee805b323b45fca30430cefe91cfd, we can
eliminate the code explicitly setting `_DARWIN_C_SOURCE`.
