### PR TITLE
Refine GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+  - package-ecosystem: github-actions
+      directory: "/"
+      schedule:
+        interval: weekly
+      open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
   install-cross:
     runs-on: ubuntu-latest
     steps:
-      - uses: XAMPPRocky/get-github-release@v1
+      - uses: XAMPPRocky/get-github-release@f014caa45687655545637a005866289b3af8c69e # v1.0.4
         id: cross
         with:
           owner: rust-embedded
           repo: cross
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}
@@ -33,11 +33,11 @@ jobs:
     # artifacts are downloaded first.
     needs: install-cross
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           submodules: true
       - if: matrix.mingw_package
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff # v2
         with:
           release: false
           install: ${{ matrix.mingw_package }}
@@ -66,7 +66,7 @@ jobs:
     # macOS isn't currently using this either, but see the note about Windows above.
     needs: install-cross
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           submodules: true
       - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
@@ -83,12 +83,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: install-cross
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           submodules: true
 
       - name: Download Cross
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: cross-linux-musl
           path: /tmp/


### PR DESCRIPTION
- Setup Dependabot for GHA
- Upgrade some external actions
- Pin hash instead of tag to reduce security risk
	- it's less readable but Dependabot will take care of upgrades by tag in comments