### PR TITLE
Prepare 1.1.9 release

### DIFF
--- a/Cargo-zng.toml
+++ b/Cargo-zng.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-ng-sys"
-version = "1.1.8"
+version = "1.1.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
 links = "z-ng"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
 links = "z"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Note that we have to release `libz-ng-sys` too by `cargo-zng publish`.
r? @Mark-Simulacrum 