### PR TITLE
Update zlib-ng to 2.1.3

### DIFF
--- a/ci/test.bash
+++ b/ci/test.bash
@@ -39,3 +39,32 @@ mv Cargo-zng.toml Cargo.toml
 mv systest/Cargo-zng.toml systest/Cargo.toml
 $CROSS test --target $TARGET_TRIPLE
 $CROSS run --target $TARGET_TRIPLE --manifest-path systest/Cargo.toml
+
+echo === flate2 validation ===
+git clone https://github.com/rust-lang/flate2-rs flate2
+git worktree add flate2/libz-sys
+git worktree add flate2/libz-ng-sys
+
+cd flate2
+(cd libz-sys
+  git submodule update --init
+)
+(cd libz-ng-sys
+  git submodule update --init
+  mv systest/Cargo-zng.toml systest/Cargo.toml
+  mv Cargo-zng.toml Cargo.toml
+)
+
+echo "[workspace]" >> Cargo.toml
+mkdir .cargo
+cat <<EOF >.cargo/config.toml
+[patch."crates-io"]
+libz-sys = { path = "./libz-sys" }
+libz-ng-sys = { path = "./libz-ng-sys" }
+EOF
+
+set -x
+$CROSS test --features zlib --target $TARGET_TRIPLE
+$CROSS test --features zlib-default --no-default-features --target $TARGET_TRIPLE
+$CROSS test --features zlib-ng --no-default-features --target $TARGET_TRIPLE
+$CROSS test --features zlib-ng-compat --no-default-features --target $TARGET_TRIPLE

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -3,6 +3,7 @@ use std::env;
 fn main() {
     let zng = env::var("CARGO_PKG_NAME").unwrap() == "systest-zng";
     let mut cfg = ctest2::TestGenerator::new();
+    cfg.define("WITH_GZFILEOP", Some("ON"));
     let (header, dep_include) = if zng {
         ("zlib-ng.h", "DEP_Z_NG_INCLUDE")
     } else {
@@ -20,8 +21,13 @@ fn main() {
             if rust == "zlibVersion" {
                 return "zlibng_version".to_string();
             }
-            format!("zng_{}", rust)
+            if rust.starts_with("zng_") {
+                rust.to_string()
+            } else {
+                format!("zng_{}", rust)
+            }
         });
+        cfg.cfg("zng", None);
     }
     cfg.type_name(move |n, _, _| {
         if zng {
@@ -35,6 +41,8 @@ fn main() {
                 return "size_t".to_string();
             } else if n == "z_checksum" {
                 return "uint32_t".to_string();
+            } else if n == "z_off_t" {
+                return "z_off64_t".to_string();
             }
         } else {
             if n == "z_size" {


### PR DESCRIPTION
zlib-ng 2.1.2 is the first stable release of the 2.1.x branch.

Most important optimizations and Enhancements:

* Decompression is a lot faster (56% faster measured on AVX2-capable x86-64)
* Compresson is improved for Level 9, at the cost of a little performance.
* Compression is improved for Level 3, by switching from deflate_fast to deflate_medium.

[Full changelog](https://github.com/zlib-ng/zlib-ng/releases/tag/2.1.2)