### PR TITLE
Allow using vcpkg for all Windows targets, and use find_package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ libc = { version = "0.2.43", optional = true }
 pkg-config = "0.3.9"
 cc = "1.0.18"
 cmake = { version = "0.1.44", optional = true }
-
-[target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -162,8 +162,7 @@ fn try_vcpkg() -> bool {
     // see if there is a vcpkg tree with zlib installed
     match vcpkg::Config::new()
         .emit_includes(true)
-        .lib_names("zlib", "zlib1")
-        .probe("zlib")
+        .find_package("zlib")
     {
         Ok(_) => true,
         Err(e) => {

--- a/build.rs
+++ b/build.rs
@@ -42,7 +42,7 @@ fn main() {
         }
     }
 
-    if target.contains("msvc") {
+    if target.contains("windows") {
         if try_vcpkg() {
             return;
         }
@@ -158,12 +158,6 @@ mod build_zng;
 #[cfg(feature = "zlib-ng")]
 use build_zng::build_zlib_ng;
 
-#[cfg(not(target_env = "msvc"))]
-fn try_vcpkg() -> bool {
-    false
-}
-
-#[cfg(target_env = "msvc")]
 fn try_vcpkg() -> bool {
     // see if there is a vcpkg tree with zlib installed
     match vcpkg::Config::new()


### PR DESCRIPTION
`vcpkg-rs` doesn't support `-pc-windows-gnu` (mingw) _yet_, but its integration tests will try to build `libz-sys`, which currently prevents using `vcpkg` for non-`msvc` targets.

This change should have no effect for `libz-sys` right now, but unblocks that work.

This also switches from `vcpkg::lib_names`/`probe` to `vcpkg::find_package`, which reliably gets the library names. Previously, this had hard coded assumptions using MSVC-style library naming (no `lib` prefix).