### PR TITLE
Fix build on x86_64

### DIFF
--- a/build_zng.rs
+++ b/build_zng.rs
@@ -22,9 +22,14 @@ pub fn build_zlib_ng(target: &str, compat: bool) {
 
     let includedir = install_dir.join("include");
     let libdir = install_dir.join("lib");
+    let libdir64 = install_dir.join("lib64");
     println!(
         "cargo:rustc-link-search=native={}",
         libdir.to_str().unwrap()
+    );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        libdir64.to_str().unwrap()
     );
     let mut debug_suffix = "";
     let libname = if target.contains("windows") && target.contains("msvc") {


### PR DESCRIPTION
On same platform, library file is compiled into `lib64` directory. Rust compiler expects that library will be in `lib` directory. This fixes this by searing library both in `lib` and `lib64` directory.