### PR TITLE
bump patch level for hotfix release

### DIFF
--- a/Cargo-zng.toml
+++ b/Cargo-zng.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-ng-sys"
-version = "1.1.10"
+version = "1.1.11"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
 links = "z-ng"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.1.10"
+version = "1.1.11"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
 links = "z"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
libz-sys should now build on non-debian linuxes again which need a different
search path.
