### PR TITLE
Correct README typo for libz-ng-sys

### DIFF
--- a/README-zng.md
+++ b/README-zng.md
@@ -4,7 +4,7 @@ A library for linking zlib-ng (`libz-ng`) to Rust programs natively, rather
 than in zlib-compat mode.
 
 zlib-ng is a high-performance implementation of zlib. zlib-ng supports building
-in two modes: zlib-compat mode, in whih it provides the same API as zlib and
+in two modes: zlib-compat mode, in which it provides the same API as zlib and
 generally works as a drop-in replacement, and native mode, in which it provides
 its own API. The native API is almost identical to the zlib-compat API, except
 that some types use more correct sizes (rather than the sizes required for zlib


### PR DESCRIPTION
Noticed a minor typo in this README.