### PR TITLE
Also emit DEP_Z_INCLUDE when using pkg-config

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,16 @@ fn main() {
             .print_system_libs(false)
             .probe("zlib");
         match zlib {
-            Ok(_) => return,
+            Ok(zlib) => {
+                if !zlib.include_paths.is_empty() {
+                    let paths = zlib
+                        .include_paths
+                        .iter()
+                        .map(|s| s.display().to_string())
+                        .collect::<Vec<_>>();
+                    println!("cargo:include={}", paths.join(","));
+                }
+            }
             Err(e) => {
                 println!("cargo-warning={}", e.to_string())
             }


### PR DESCRIPTION
Downstream build scripts use `DEP_Z_INCLUDE` to configure the builds of other native libraries (for example in [libgit2-sys](https://github.com/rust-lang/git2-rs/blob/master/libgit2-sys/build.rs#L226)). Previously, if libz was found via pkg-config and didn't have a system-default include directory those builds would fail.