### PR TITLE
cc: Only enable ARM_NEON when in target_feature

### DIFF
--- a/zng/cc.rs
+++ b/zng/cc.rs
@@ -196,6 +196,7 @@ pub fn build_zlib_ng(target: &str, compat: bool) {
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("failed to retrieve target arch");
+    let features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap();
 
     let is_linux_or_android = matches!(target_os.as_str(), "linux" | "android");
     if is_linux_or_android {
@@ -311,7 +312,9 @@ pub fn build_zlib_ng(target: &str, compat: bool) {
             }
 
             // neon
-            cfg.define("ARM_NEON", None);
+            if features.contains("neon") {
+                cfg.define("ARM_NEON", None);
+            }
 
             // NOTE: These intrinsics were only added in gcc 9.4, which is _relatively_
             // recent, and if the define is not set zlib-ng just provides its

--- a/zng/cc.rs
+++ b/zng/cc.rs
@@ -312,7 +312,9 @@ pub fn build_zlib_ng(target: &str, compat: bool) {
             }
 
             // neon
-            if features.split(",").any(|name| name == "neon")
+            // Fix armv7-unknown-linux-musleabi and arm-unknown-linux-musleabi by only
+            // passing in ARM_NEON if that target is enabled.
+            if features.split(",").any(|name| name == "neon") {
                 cfg.define("ARM_NEON", None);
             }
 

--- a/zng/cc.rs
+++ b/zng/cc.rs
@@ -312,7 +312,7 @@ pub fn build_zlib_ng(target: &str, compat: bool) {
             }
 
             // neon
-            if features.contains("neon") {
+            if features.split(",").any(|name| name == "neon")
                 cfg.define("ARM_NEON", None);
             }
 


### PR DESCRIPTION
* Fix armv7-unknown-linux-musleabi and arm-unknown-linux-musleabi by only passing in ARM_NEON if that target is enabled.
* This was only tested without neon, and *not* tested *with* neon support

To enable NEON in the future, I think the following will need to be addressed with adding compiler options:
```
  cargo:warning=                 from src/zlib-ng/arch/arm/slide_hash_neon.c:12:
  cargo:warning=/usr/local/lib/gcc/arm-linux-musleabi/9.2.0/include/arm_neon.h:31:2: error: #error "NEON intrinsics not available with the soft-float ABI.  Please use -mfloat-abi=softfp or -mfloat-abi=hard"
  cargo:warning=   31 | #error "NEON intrinsics not available with the soft-float ABI.  Please use -mfloat-abi=softfp or -mfloat-abi=hard"
```