### PR TITLE
fix typo in the s390/s390x inclusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.1.18"
+version = "1.1.19"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Josh Triplett <josh@joshtriplett.org>",
@@ -30,7 +30,7 @@ include = [
     "src/zlib-ng/arch/generic/**.[ch]",
     "src/zlib-ng/arch/power/**.[ch]",
     "src/zlib-ng/arch/riscv/**.[ch]",
-    "src/zlib-ng/arch/s390x/**.[ch]",
+    "src/zlib-ng/arch/s390/**.[ch]",
     "src/zlib-ng/arch/x86/**.[ch]",
     "src/zlib-ng/*.[ch].in",
     "src/zlib-ng/*.pc.in",


### PR DESCRIPTION
fixes #204 

the typo meant that some C files were not included in the build, which caused the published version of this crate to fail for s390x targets

Also bumps the version because having this fixed on crates.io would be nice.

```
> ls src/zlib-ng/arch
arm  generic  power  riscv  s390  x86
```