### PR TITLE
Add LIB_SYS_TRY_SHARED ENV var to try to link with shared library

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -82,10 +82,12 @@ fn main() {
     // Apple platforms have libz.1.dylib, and it's usually available even when
     // cross compiling (via fat binary or in the target's Xcode SDK)
     let cross_compiling = target != host;
+    let try_link_with_shared =
+        env::var("LIB_SYS_TRY_SHARED").unwrap_or(String::new()) == "1";
     if target.contains("msvc")
         || target.contains("pc-windows-gnu")
         || want_static
-        || (cross_compiling && !target.contains("-apple-"))
+        || !try_link_with_shared && (cross_compiling && !target.contains("-apple-"))
     {
         return build_zlib(&mut cfg, &target);
     }


### PR DESCRIPTION
On cross-compilation libz-sys is always building static zlib library, except for Apple platforms. If target has an installed zlib shared library, this is problem, because:

  1. the binary is increased, because we are including a static zlib as well
  2. it may cause build issues if the pkg-config sets the linker arguments, like this:

     /tmp/rustc0ZqD0F/liblibz_sys-84983a050a121d20.rlib(inflate.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol '__stack_chk_guard' which may bind externally can not be used when making a shared object; recompile with -fPIC

To workaround the issue, add a LIB_SYS_TRY_SHARED=1 ENV var (similarly to LIBZ_SYS_STATIC=1) to force the use of the shared library, recognized by the pkg-config.

fixes #201 