### PR TITLE
Treat `\` in `cargo package -l` output as `/`

### DIFF
--- a/cargo-zng
+++ b/cargo-zng
@@ -2,7 +2,11 @@
 set -eu
 trap 'rm -rf "$tempdir"' 0 INT
 tempdir="$(mktemp -d)"
-cargo package -l --allow-dirty | grep -v '^Cargo\.toml\.orig$' | tar --files-from=- -cf - | tar -C "$tempdir" -xf -
+cargo package -l --allow-dirty |
+    tr '\\' '/' |
+    grep -v '^Cargo\.toml\.orig$' |
+    tar --files-from=- -cf - |
+    tar -C "$tempdir" -xf -
 cp Cargo-zng.toml "$tempdir/Cargo.toml"
 cp -a systest "$tempdir/systest"
 mv "$tempdir/systest/Cargo-zng.toml" "$tempdir/systest/Cargo.toml"


### PR DESCRIPTION
Fixes #212

`tr`-ing the `\` characters to `/` in the output of `cargo package -l` makes the `tar` pipeline work and allows the build to succeed on Windows, presumably since files needed by `cmake` are now available:

```text
ek@Glub MINGW64 ~/source/repos/libz-sys (dirsep)
$ ./cargo-zng build
    Updating crates.io index
     Locking 40 packages to latest compatible versions
      Adding bitflags v1.3.2 (latest: v2.6.0)
      Adding cfg-if v0.1.10 (latest: v1.0.0)
      Adding dirs v2.0.2 (latest: v5.0.1)
      Adding dirs-sys v0.3.7 (latest: v0.4.1)
      Adding term v0.6.1 (latest: v1.0.0)
      Adding wasi v0.11.0+wasi-snapshot-preview1 (latest: v0.13.2+wasi-0.2.1)
   Compiling shlex v1.3.0
   Compiling libc v0.2.158
   Compiling cc v1.1.16
   Compiling cmake v0.1.51
   Compiling libz-ng-sys v1.1.16 (C:\Users\ek\AppData\Local\Temp\tmp.s82mZvB6O0)
warning: unexpected `cfg` condition value: `libc`
  --> src\lib.rs:31:16
   |
31 | #[cfg(any(zng, feature = "libc"))]
   |                ^^^^^^^^^^^^^^^^ help: remove the condition
   |
   = note: no expected values for `feature`
   = help: consider adding `libc` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: requested on the command line with `-W unexpected-cfgs`

warning: unexpected `cfg` condition value: `libc`
  --> src\lib.rs:42:16
   |
42 | #[cfg(any(zng, feature = "libc"))]
   |                ^^^^^^^^^^^^^^^^ help: remove the condition
   |
   = note: no expected values for `feature`
   = help: consider adding `libc` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `libc`
  --> src\lib.rs:48:5
   |
48 |     feature = "libc",
   |     ^^^^^^^^^^^^^^^^ help: remove the condition
   |
   = note: no expected values for `feature`
   = help: consider adding `libc` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `libc`
  --> src\lib.rs:55:5
   |
55 |     feature = "libc",
   |     ^^^^^^^^^^^^^^^^ help: remove the condition
   |
   = note: no expected values for `feature`
   = help: consider adding `libc` as a feature in `Cargo.toml`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `libc`
   --> src\lib.rs:327:16
    |
327 | #[cfg(any(zng, feature = "libc"))]
    |                ^^^^^^^^^^^^^^^^ help: remove the condition
    |
    = note: no expected values for `feature`
    = help: consider adding `libc` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: `libz-ng-sys` (lib) generated 5 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 33.26s
```

(Those warnings are separate from this change and also occur without it on other systems and with `cargo build`.)

I tested on Ubuntu 24.04 LTS and macOS 14.6, and this change does not seem to have broken or degraded them. I noticed this on macOS, but it *also* happens on macOS on the main branch and thus appears independent of this change:

```text
tar: .cargo_vcs_info.json: Cannot stat: No such file or directory
tar: Error exit delayed from previous errors.
```

Since that appears altogether separate from this, I've opened #214 for it.

In all tests, I used `cargo clean -xde` between the build (though I think actually no cleaning is really needed, since a temporary directory is used and it is different each time). To make sure this really was fixing the build on Windows, I re-cloned the repository and retested as well.

The only commands I have tested are `./cargo-zng` and `./cargo-zng build`. I have not tested publishing.