### PR TITLE
Also `grep -v` out `.cargo_vcs_info.json` in `cargo-zng`

### DIFF
--- a/cargo-zng
+++ b/cargo-zng
@@ -4,7 +4,7 @@ tempdir="$(mktemp -d)"
 trap 'rm -rf "$tempdir"' 0 INT
 cargo package -l --allow-dirty |
     tr '\\' '/' |
-    grep -v '^Cargo\.toml\.orig$' |
+    grep -vxF -e Cargo.toml.orig -e .cargo_vcs_info.json |
     tar --files-from=- -cf - |
     tar -C "$tempdir" -xf -
 cp Cargo-zng.toml "$tempdir/Cargo.toml"


### PR DESCRIPTION
Fixes #214

In the `cargo-zng` script, this has the `grep -v` command that filters out `Cargo.toml.orig` also filiter out `.cargo_vcs_info.json`.

It also refactors the command to use fixed string (`-F`) and match whole lines (`-x`), to eliminate the `^` and `$` anchors and `\` escapes from the pattern(s).

This is working for `./cargo-zng` and `./cargo-zng build` on Ubuntu 24.04 LTS, macOS 14.6, and Windows 10 in Git Bash.