### PR TITLE
ohos: Link shared lib on OpenHarmony

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,9 +23,9 @@ fn main() {
     }
 
     // All android compilers should come with libz by default, so let's just use
-    // the one already there. Likewise, Haiku always ships with libz, so we can
-    // link to it even when cross-compiling.
-    if target.contains("android") || target.contains("haiku") {
+    // the one already there. Likewise, Haiku and OpenHarmony always ship with libz,
+    // so we can link to it even when cross-compiling.
+    if target.contains("android") || target.contains("haiku") || target.ends_with("-ohos") {
         println!("cargo:rustc-link-lib=z");
         return;
     }


### PR DESCRIPTION
The OpenHarmony SDK / sysroot contains libz.so and similar to android we can assume that libz will always be available, 
since the [OpenHarmony zlib documentation](https://docs.openharmony.cn/pages/v5.0/en/application-dev/reference/native-lib/zlib.md) exists and explicitly mentions linking against `libz.so`.

OpenHarmony is supported as a tier 2 target in rustc as [*-linux-ohos](https://doc.rust-lang.org/rustc/platform-support/openharmony.html)