### PR TITLE
bump `zlib-ng` to version `2.2.3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.1.20"
+version = "1.1.21"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Josh Triplett <josh@joshtriplett.org>",


### PR DESCRIPTION
Updates to the latest zlib-ng release https://github.com/zlib-ng/zlib-ng/releases/tag/2.2.3, released last week.