### PR TITLE
bump `zng` to 1.1.21

### DIFF
--- a/Cargo-zng.toml
+++ b/Cargo-zng.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-ng-sys"
-version = "1.1.20"
+version = "1.1.21"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Josh Triplett <josh@joshtriplett.org>",


### PR DESCRIPTION
It looks like the `zng` and "vanilla" version release in tandem? or should the version bump of `Cargo.toml` be reverted?