### PR TITLE
Fix unnecessary search path warning on macOS

### DIFF
--- a/zng/cmake.rs
+++ b/zng/cmake.rs
@@ -39,18 +39,18 @@ pub fn build_zlib_ng(target: &str, compat: bool) {
         cmake.define("CMAKE_GENERATOR_PLATFORM", "Win32");
     }
 
+    // libz-ng uses the GNUInstallDirs convention, so we can use the following
+    // to ensure libraries are placed in a consistent place in the
+    // installation dir.
+    cmake.define("CMAKE_INSTALL_LIBDIR", "lib");
+
     let install_dir = cmake.build();
 
     let includedir = install_dir.join("include");
     let libdir = install_dir.join("lib");
-    let libdir64 = install_dir.join("lib64");
     println!(
         "cargo:rustc-link-search=native={}",
         libdir.to_str().unwrap()
-    );
-    println!(
-        "cargo:rustc-link-search=native={}",
-        libdir64.to_str().unwrap()
     );
     let mut debug_suffix = "";
     let libname = if target.contains("windows") && target.contains("msvc") {


### PR DESCRIPTION
The linker on macOS warns on unused search paths, and concretely, when compiling `zlib-ng` via this crate, it warns with:
```
ld: search path 'target/debug/build/libz-sys-3eb8b95c9c44bf93/out/lib64' not found
```

This warning has previously been hidden away, but `rustc` wants to surface them by default [at some point](https://github.com/rust-lang/rust/issues/136096).

So let's avoid the warning by setting `CMAKE_INSTALL_LIBDIR` explicitly, and then only passing a single search path to the linker.

Can be tested on macOS with:
```console
$ RUSTFLAGS="-Wlinker-messages" cargo +nightly test --no-default-features --features zlib-ng
```