### PR TITLE
bump `zlib-ng` to version `2.2.4`

### DIFF
--- a/Cargo-zng.toml
+++ b/Cargo-zng.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-ng-sys"
-version = "1.1.21"
+version = "1.1.22"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Josh Triplett <josh@joshtriplett.org>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.22"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Josh Triplett <josh@joshtriplett.org>",


### PR DESCRIPTION
turns out zlib-ng had another release, with mostly bug fixes https://github.com/zlib-ng/zlib-ng/releases/tag/2.2.4.

Not urgent at all but we may as well stay up to date.

