### PR TITLE
fix: Remove forcing static builds when cross-compiling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -75,17 +75,12 @@ fn main() {
 
     // Situations where we build unconditionally.
     //
-    // MSVC basically never has it preinstalled, MinGW picks up a bunch of weird
-    // paths we don't like, `want_static` may force us, and cross compiling almost
-    // never has a prebuilt version.
-    //
-    // Apple platforms have libz.1.dylib, and it's usually available even when
-    // cross compiling (via fat binary or in the target's Xcode SDK)
-    let cross_compiling = target != host;
+    // - MSVC basically never has zlib preinstalled
+    // - MinGW picks up a bunch of weird paths we don't like
+    // - Explicit opt-in via `want_static`
     if target.contains("msvc")
         || target.contains("pc-windows-gnu")
         || want_static
-        || (cross_compiling && !target.contains("-apple-"))
     {
         return build_zlib(&mut cfg, &target);
     }
@@ -101,6 +96,7 @@ fn main() {
         return;
     }
 
+    // For convenience fallback to building zlib if attempting to link zlib failed
     build_zlib(&mut cfg, &target)
 }
 


### PR DESCRIPTION
This constraint is no longer necessary, due to improvements since it's original introduction in Feb 2016.

The zlib library will be linked dynamically (provided no explicit opt-in to static link) or fallback to building from source.

---

More details with discussion/history is covered here: https://github.com/rust-lang/libz-sys/pull/206#issuecomment-3026759631

**Notably:**
- A project should not link zlib both dynamically (_via another crate linking system deps that bring in zlib_) and statically (_vendored via `libz-sys`_): https://github.com/rust-lang/libz-sys/issues/201
- Building a target as a native arch or cross-compiled arch should not cause linking between dynamic vs static to occur when zlib is discoverable to link dynamically.

This PR ensures building for the target is consistent across correctly configured build environments.