### PR TITLE
fix: Support opt-out of static linking via `LIBZ_SYS_STATIC=0`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -238,11 +238,11 @@ fn zlib_installed(cfg: &mut cc::Build) -> bool {
     false
 }
 
-// The environment variable `LIBZ_SYS_STATIC` is first checked for a value of `0` (false) or `1` (true),
-// before considering the `static` feature when no explicit ENV value was detected.
-// When `libz-sys` is a transitive dependency from a crate that forces static linking via the `static` feature,
-// this enables the build environment to revert that preference via `LIBZ_SYS_STATIC=0`.
-// The default is otherwise `false`.
+/// The environment variable `LIBZ_SYS_STATIC` is first checked for a value of `0` (false) or `1` (true),
+/// before considering the `static` feature when no explicit ENV value was detected.
+/// When `libz-sys` is a transitive dependency from a crate that forces static linking via the `static` feature,
+/// this enables the build environment to revert that preference via `LIBZ_SYS_STATIC=0`.
+/// The default is otherwise `false`.
 fn should_link_static() -> bool {
   let has_static_env: Option<&'static str> = option_env!("LIBZ_SYS_STATIC");
   let has_static_cfg = cfg!(feature = "static");


### PR DESCRIPTION
This change refactors the `want_static` logic to additionally support `LIBZ_SYS_STATIC=0` as an [explicit opt-out to the `static` feature when `libz-sys` is a transitive dependency](https://github.com/rust-lang/libz-sys/issues/201#issuecomment-2291519891) and the build environment prefers to dynamic link `libz` instead.

I've inlined some rough commentary should it help grokking the helper method to maintainers (_and any future contributors_), with clear intent of supporting opt-out from the crate's `static` feature. This could probably do with some revision, along with [user visible documentation](https://github.com/rust-lang/libz-sys/pull/206#issuecomment-2325610571) of ENV precedence over the crate feature.

---

## Future work

A follow-up PR may want to further refactor the following with [consideration of `LIBZ_SYS_STATIC` explicitly forcing a linkage preference](https://github.com/rust-lang/libz-sys/pull/206#issuecomment-2294758685) as opposed to convenience fallback/assumptions (_the commentary was contributed some time ago and lacks further context/sources_):

https://github.com/rust-lang/libz-sys/blob/80c597a07f5e5f0dff0e98c03d48a77845de9f6e/build.rs#L25-L31

https://github.com/rust-lang/libz-sys/blob/80c597a07f5e5f0dff0e98c03d48a77845de9f6e/build.rs#L39-L42

https://github.com/rust-lang/libz-sys/blob/80c597a07f5e5f0dff0e98c03d48a77845de9f6e/build.rs#L76-L86

https://github.com/rust-lang/libz-sys/blob/80c597a07f5e5f0dff0e98c03d48a77845de9f6e/build.rs#L88-L100

Likewise a follow-up PR may want to consider [dynamic link support for `zlib-ng`](https://github.com/rust-lang/libz-sys/issues/158):

https://github.com/rust-lang/libz-sys/blob/80c597a07f5e5f0dff0e98c03d48a77845de9f6e/build.rs#L16-L23

The zlib logic already enforces a build if `want_static == true`, otherwise runs a test to check if a system library is available to link, and if not falls back to building from source.

## References

For anyone engaging on the topic/support, these might be of interest:
- [Historical context](https://github.com/rust-lang/libz-sys/pull/206#issuecomment-3026759631)
- [Removal of enforced static linking for cross-compilation](https://github.com/rust-lang/libz-sys/pull/244)
- [Cross-compilation example with pkg-config](https://github.com/rust-lang/libz-sys/pull/206#issuecomment-3026759898)
- [Conventions used by other sys crates](https://github.com/rust-lang/libz-sys/pull/206#issuecomment-2325455490)
  - `<CRATE>_NO_VENDOR=1` (git, openssl)
  - `<CRATE>_USE_PKG_CONFIG=1` (ssh, zstd, sqlite)
  - `<CRATE>_STATIC=0` (pcre2, libz)
