### PR TITLE
zlib-ng: Include loongarch architecture folder

### DIFF
--- a/Cargo-zng.toml
+++ b/Cargo-zng.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-ng-sys"
-version = "1.1.28"
+version = "1.1.29"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Josh Triplett <josh@joshtriplett.org>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Josh Triplett <josh@joshtriplett.org>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ include = [
     "src/zlib-ng/**.[ch]",
     "src/zlib-ng/arch/arm/**.[ch]",
     "src/zlib-ng/arch/generic/**.[ch]",
+    "src/zlib-ng/arch/loongarch/**.[ch]",
     "src/zlib-ng/arch/power/**.[ch]",
     "src/zlib-ng/arch/riscv/**.[ch]",
     "src/zlib-ng/arch/s390/**.[ch]",


### PR DESCRIPTION
Otherwise building zlib-ng for loongarch64 would fail since the CMakeLists.txt was referencing missing files.