### PR TITLE
forward the `crc` target feature on aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         platform: [linux-musl]
 
   windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner || 'windows-latest' }}
     # Windows technically doesn't need this, but if we don't block windows on it
     # some of the windows jobs could fill up the concurrent job queue before
     # one of the install-cross jobs has started, so this makes sure all
@@ -55,11 +55,14 @@ jobs:
           - x86_64-pc-windows-gnu
           - i686-pc-windows-msvc
           - i686-pc-windows-gnu
+          - aarch64-pc-windows-msvc
         include:
           - target: x86_64-pc-windows-gnu
             mingw_package: mingw-w64-x86_64-gcc
           - target: i686-pc-windows-gnu
             mingw_package: mingw-w64-i686-gcc
+          - target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
 
   macos:
     runs-on: macos-latest

--- a/build.rs
+++ b/build.rs
@@ -137,6 +137,17 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
         cfg.flag("-fvisibility=hidden");
     }
 
+    // Forward target features to the C compiler.
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+    let target_features: std::collections::HashSet<&str> = features.split(',').collect();
+
+    // Using the crc32x instruction gives a 10X speedup on crc32.
+    if arch == "aarch64" && target_features.contains("crc") {
+        // NOTE: the msvc C compiler does not support this flag.
+        cfg.flag_if_supported("-march=armv8-a+crc");
+    }
+
     cfg.compile("z");
 
     fs::create_dir_all(dst.join("include")).unwrap();

--- a/ci/test.bash
+++ b/ci/test.bash
@@ -32,6 +32,11 @@ fi
 $CROSS test --target $TARGET_TRIPLE
 $CROSS run --target $TARGET_TRIPLE --manifest-path systest/Cargo.toml
 
+echo '::group::=== static build ==='
+$CROSS test --target $TARGET_TRIPLE --features static
+$CROSS run --target $TARGET_TRIPLE --manifest-path systest/Cargo.toml --features libz-static
+echo '::endgroup::'
+
 echo '::group::=== zlib-ng build ==='
 $CROSS test --target $TARGET_TRIPLE --no-default-features --features zlib-ng
 $CROSS run --target $TARGET_TRIPLE --manifest-path systest/Cargo.toml --no-default-features --features zlib-ng

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -55,9 +55,26 @@ fn main() {
             n.to_string()
         }
     });
-    cfg.skip_signededness(|ty| matches!(ty,
-        "gz_headerp" | "voidpf" | "voidcf" | "voidp" | "out_func" | "voidpc" | "gzFile"
-        | "in_func" | "free_func" | "alloc_func" | "z_streamp"));
+    cfg.skip_signededness(|ty| {
+        matches!(
+            ty,
+            "gz_headerp"
+                | "voidpf"
+                | "voidcf"
+                | "voidp"
+                | "out_func"
+                | "voidpc"
+                | "gzFile"
+                | "in_func"
+                | "free_func"
+                | "alloc_func"
+                | "z_streamp"
+        )
+    });
     cfg.skip_field_type(|s, field| s == "z_stream" && (field == "next_in" || field == "msg"));
+    if let Ok("msvc") = env::var("CARGO_CFG_TARGET_ENV").as_deref() {
+        // Suppress C4746: ctest2 generates volatile accesses that MSVC errors on.
+        cfg.flag("/wd4746");
+    }
     cfg.generate("../src/lib.rs", "all.rs");
 }


### PR DESCRIPTION
When statically linking `zlib` (i.e. when building it from source), forward the `crc` target feature. `zlib` does not dynamically detect it, and apparently it is not part of the baseline feature set in C.