### PR TITLE
Only define Z_SOLO on wasm32-unknown-unknown, not the wasi/emscripten targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,20 @@ jobs:
       # The threads ABI imports shared memory, which needs a custom host.
       - run: cargo test --target wasm32-wasip1-threads --test wasm --no-run
 
+  wasm-emscripten:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER: node
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+      - uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
+        with:
+          version: 6.0.4
+      - run: rustup target add wasm32-unknown-emscripten
+      - run: cargo test --target wasm32-unknown-emscripten --test wasm --features static
+
   windows:
     runs-on: ${{ matrix.runner || 'windows-latest' }}
     # Windows technically doesn't need this, but if we don't block windows on it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,23 @@ jobs:
       matrix:
         platform: [linux-musl]
 
+  wasm:
+    runs-on: ubuntu-latest
+    env:
+      CC_wasm32_wasip1: /tmp/wasi-sdk-33.0-x86_64-linux/bin/clang
+      AR_wasm32_wasip1: /tmp/wasi-sdk-33.0-x86_64-linux/bin/llvm-ar
+      CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+      - uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1
+        with:
+          version: 46.0.1
+      - run: rustup target add wasm32-wasip1
+      - run: curl -fsSL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | tar xz -C /tmp
+      - run: cargo test --target wasm32-wasip1 --test wasm
+
   windows:
     runs-on: ${{ matrix.runner || 'windows-latest' }}
     # Windows technically doesn't need this, but if we don't block windows on it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,17 @@ jobs:
           test -n "$archive"
           ! /tmp/wasi-sdk-33.0-x86_64-linux/bin/llvm-nm -u "$archive" | grep -Eq ' U (malloc|free)$'
 
-  wasm:
+  wasm-wasi:
     runs-on: ubuntu-latest
     env:
       CC_wasm32_wasip1: /tmp/wasi-sdk-33.0-x86_64-linux/bin/clang
       AR_wasm32_wasip1: /tmp/wasi-sdk-33.0-x86_64-linux/bin/llvm-ar
       CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
+      CC_wasm32_wasip1_threads: /tmp/wasi-sdk-33.0-x86_64-linux/bin/clang
+      AR_wasm32_wasip1_threads: /tmp/wasi-sdk-33.0-x86_64-linux/bin/llvm-ar
+      CC_wasm32_wasip2: /tmp/wasi-sdk-33.0-x86_64-linux/bin/clang
+      AR_wasm32_wasip2: /tmp/wasi-sdk-33.0-x86_64-linux/bin/llvm-ar
+      CARGO_TARGET_WASM32_WASIP2_RUNNER: wasmtime
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -56,9 +61,12 @@ jobs:
       - uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1
         with:
           version: 46.0.1
-      - run: rustup target add wasm32-wasip1
+      - run: rustup target add wasm32-wasip1 wasm32-wasip1-threads wasm32-wasip2
       - run: curl -fsSL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | tar xz -C /tmp
       - run: cargo test --target wasm32-wasip1 --test wasm
+      - run: cargo test --target wasm32-wasip2 --test wasm
+      # The threads ABI imports shared memory, which needs a custom host.
+      - run: cargo test --target wasm32-wasip1-threads --test wasm --no-run
 
   windows:
     runs-on: ${{ matrix.runner || 'windows-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,24 @@ jobs:
       matrix:
         platform: [linux-musl]
 
+  wasm-no-libc:
+    runs-on: ubuntu-latest
+    env:
+      CRATE_CC_NO_DEFAULTS: 1
+      CC_wasm32_unknown_unknown: /tmp/wasi-sdk-33.0-x86_64-linux/bin/clang --target=wasm32-unknown-unknown
+      AR_wasm32_unknown_unknown: /tmp/wasi-sdk-33.0-x86_64-linux/bin/llvm-ar
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+      - run: rustup target add wasm32-unknown-unknown
+      - run: curl -fsSL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | tar xz -C /tmp
+      - run: cargo build --target wasm32-unknown-unknown --no-default-features --features stock-zlib
+      - run: |
+          archive=$(find target/wasm32-unknown-unknown/debug/build -path '*/out/lib/libz.a' -print -quit)
+          test -n "$archive"
+          ! /tmp/wasi-sdk-33.0-x86_64-linux/bin/llvm-nm -u "$archive" | grep -Eq ' U (malloc|free)$'
+
   wasm:
     runs-on: ubuntu-latest
     env:

--- a/build.rs
+++ b/build.rs
@@ -116,7 +116,13 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
         .file("src/zlib/uncompr.c")
         .file("src/zlib/zutil.c");
 
-    if target.starts_with("wasm32") {
+    // Z_SOLO is zlib's "no C library at all" mode: it removes the default
+    // zalloc/zfree (so the one-shot compress()/uncompress() helpers return
+    // Z_STREAM_ERROR unless the caller wires up allocators by hand) and the
+    // gz* file API. Of the wasm32 targets only wasm32-unknown-unknown has no
+    // libc; the wasi targets (wasi-libc) and emscripten ship a complete C
+    // library, so they get the standard build.
+    if target == "wasm32-unknown-unknown" {
         cfg.define("Z_SOLO", None);
         // zlib 1.3.2 uses `NULL` directly in compress.c/uncompr.c, but the
         // Z_SOLO config path doesn't pull in headers that always define it.

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,0 +1,35 @@
+#![cfg(target_os = "wasi")]
+
+#[test]
+fn compress_roundtrip() {
+    let input = b"libz-sys on WebAssembly";
+    let mut compressed = vec![0; unsafe { libz_sys::compressBound(input.len() as _) } as usize];
+    let mut compressed_len = compressed.len() as _;
+
+    assert_eq!(
+        unsafe {
+            libz_sys::compress(
+                compressed.as_mut_ptr(),
+                &mut compressed_len,
+                input.as_ptr(),
+                input.len() as _,
+            )
+        },
+        libz_sys::Z_OK
+    );
+
+    let mut output = vec![0; input.len()];
+    let mut output_len = output.len() as _;
+    assert_eq!(
+        unsafe {
+            libz_sys::uncompress(
+                output.as_mut_ptr(),
+                &mut output_len,
+                compressed.as_ptr(),
+                compressed_len,
+            )
+        },
+        libz_sys::Z_OK
+    );
+    assert_eq!(&output[..output_len as usize], input);
+}

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,4 +1,4 @@
-#![cfg(target_os = "wasi")]
+#![cfg(any(target_os = "wasi", target_os = "emscripten"))]
 
 #[test]
 fn compress_roundtrip() {


### PR DESCRIPTION
`build_zlib()` defines `Z_SOLO` for every `wasm32*` target. `Z_SOLO` is
zlib's "no C library" mode: no default `zalloc`/`zfree` — so the one-shot
helpers `compress()`/`uncompress()` always return `Z_STREAM_ERROR` at
runtime — and no `gz*` API.

Only `wasm32-unknown-unknown` actually lacks a libc. The wasi targets
link wasi-libc (full malloc/free and fd-based I/O) and emscripten ships
musl, so there the blanket define just breaks working API: on
`wasm32-wasip1`,

```rust
let rc = libz_sys::compress(dst.as_mut_ptr(), &mut dst_len,
                            src.as_ptr(), src.len() as _);
assert_eq!(rc, libz_sys::Z_OK); // fails today: rc == -2 (Z_STREAM_ERROR)
```

compiles fine and fails at runtime on every call, while the identical
program works on native targets. flate2 doesn't notice because it always
supplies its own allocators through the streaming API; direct libz-sys
users on wasi hit it with no workaround inside libz-sys.

Minimal repro (any wasi runtime, e.g. wasmtime):

```
cargo new zsolo && cd zsolo && cargo add libz-sys@1.1.29
# main.rs: call libz_sys::compress() on any buffer and print the rc
cargo build --target wasm32-wasip1 && wasmtime target/wasm32-wasip1/debug/zsolo.wasm
# prints rc = -2 (Z_STREAM_ERROR); the same program prints 0 on native
```

This PR scopes the define to `wasm32-unknown-unknown`. wasi/emscripten
now take the standard source list, including the `gz*` files, which
compile cleanly against wasi-libc (verified on wasm32-wasip1: the crate
builds, and a one-shot compress/uncompress roundtrip passes where it
returned -2 before). `src/lib.rs` needs no change — it already declares
the one-shot functions unconditionally.
